### PR TITLE
Use $this->payer as Array not object

### DIFF
--- a/lib/models/RequestToPay.php
+++ b/lib/models/RequestToPay.php
@@ -35,7 +35,7 @@ class RequestToPay implements \JsonSerializable
     public function jsonSerialize()
     {
         $data = array(
-            'payer' => array($this->payer->partyIdType, $this->payer->partyId),
+            'payer' => array($this->payer['partyIdType'], $this->payer['partyId']),
             'payeeNote' => $this->payeeNote,
             'payerMessage' => $this->payerMessage,
             'externalId' => $this->externalId,


### PR DESCRIPTION
Use $this->payer as Array because its not an object.

Steps to reproduce Error:
1. Get a transation using (new Collection)->getTransaction($token)
2. Call the jsonSerialize() method on the results.
    It will produce the error: ErrorException with message 'Trying to get property 'partyIdType' of non-object'