### PR TITLE
[WIP] - mwakaambrose/fixes-phpunit-failure-and-rebuilds-cli-tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,3 @@
 /build
 composer.lock
 phpcs.xml
-phpunit.xml

--- a/lib/Provision.php
+++ b/lib/Provision.php
@@ -1,4 +1,3 @@
-#!/usr/bin/php
 <?php
 namespace MomoApi;
 

--- a/lib/Remittance.php
+++ b/lib/Remittance.php
@@ -2,9 +2,9 @@
 
 namespace MomoApi;
 
-use MomoApi\HttpClient\ClientInterface;
-use MomoApi\models\ResourceFactory;
 use MomoApi\Util\Util;
+use MomoApi\models\ResourceFactory;
+use MomoApi\HttpClient\ClientInterface;
 
 class Remittance extends ApiRequest
 {

--- a/phpunit.xml
+++ b/phpunit.xml
@@ -1,0 +1,37 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<phpunit backupGlobals="false"
+         backupStaticAttributes="false"
+         bootstrap="tests/bootstrap.php"
+         colors="true"
+         convertErrorsToExceptions="true"
+         convertNoticesToExceptions="true"
+         convertWarningsToExceptions="true"
+         processIsolation="false"
+         stopOnFailure="false"
+         stopOnError="false"
+         beStrictAboutTestsThatDoNotTestAnything="false">
+
+    <testsuites>
+        <testsuite name="UTIL tests">
+            <directory suffix="Test.php">tests/momoapi/Util</directory>
+        </testsuite>
+        <testsuite name="Feature Tests">
+            <directory suffix="Test.php">tests/momoapi/HttpClient</directory>
+        </testsuite>
+
+        <testsuite name="Error Tests">
+            <directory suffix="Test.php">tests/momoapi/Error</directory>
+        </testsuite>
+    </testsuites>
+
+    <filter>
+        <whitelist processUncoveredFilesFromWhitelist="true">
+            <directory suffix=".php">lib</directory>
+        </whitelist>
+    </filter>
+
+    <php>
+        <env name="APP_ENV" value="testing"/>
+    </php>
+
+</phpunit>

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -1,11 +1,12 @@
 <?php
-
 namespace MomoApi;
+
+use PHPUnit\Framework\TestCase as PHPUnit_Framework_TestCase;
 
 /**
  * Base class for MomoApi test cases.
  */
-class TestCase extends \PHPUnit_Framework_TestCase
+class TestCase extends PHPUnit_Framework_TestCase
 {
     public $_baseUrl;
 


### PR DESCRIPTION
- [x] Write new phpunit configuration file and fix `\PHPUnit_Framework_TestCase` not found.
- [x] Remove `#!/usr/bin/php` declaration from `Provision.php`. Eliminates the `require_once "Util/Util.php";` in that file.
- [ ] Fix test failure from the change
- [ ] Replace `$ php vendor/sparkplug/momoapi-php/lib/Provision.php` with a cleaner `php momo provision` syntax.
- [ ] Fix test failure from the change and write more tests
- [ ] Upgrade phpunit from `~4` to `^6`. This solves the `The each() function is deprecated.` deprecation warning.
